### PR TITLE
Update README.md to reflect new config.txt location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Access the hardware PWM of a Raspberry Pi with Python. More lightweight than alt
 
 ### Installation
 
-1. On the Raspberry Pi, add `dtoverlay=pwm-2chan` to `/boot/config.txt`. This defaults to `GPIO_18` as the pin for `PWM0` and `GPIO_19` as the pin for `PWM1`.
+1. On the Raspberry Pi, add `dtoverlay=pwm-2chan` to `/boot/firmware/config.txt`. This defaults to `GPIO_18` as the pin for `PWM0` and `GPIO_19` as the pin for `PWM1`.
     - Alternatively, you can change `GPIO_18` to `GPIO_12` and `GPIO_19` to `GPIO_13` using `dtoverlay=pwm-2chan,pin=12,func=4,pin2=13,func2=4`.
     - On the Pi 5, use channels 0 and 1 to control GPIO_12 and GPIO13, respectively; use channels 2 and 3 to control GPIO_18 and GPIO_19, respectively
     - On all other models, use channels 0 and 1 to control GPIO-18 and GPIO_19, respectively


### PR DESCRIPTION
config.txt has changed location from /boot/config.txt to /boot/firmware/config.txt with the release of RPI OS Bookworm (10/10/23).

https://www.raspberrypi.com/documentation/computers/config_txt.html