### PR TITLE
Update __init__.py to match physical pins to GPIO pins

### DIFF
--- a/rpi_hardware_pwm/__init__.py
+++ b/rpi_hardware_pwm/__init__.py
@@ -12,8 +12,8 @@ class HardwarePWM:
     """
     Control the hardware PWM on the Raspberry Pi. Need to first add `dtoverlay=pwm-2chan` to `/boot/config.txt`.
 
-    pwm0 is GPIO pin 18 is physical pin 32 (dtoverlay can be deployed to use GPIO 12 instead)
-    pwm1 is GPIO pin 19 is physical pin 33 (dtoverlay can be deployed to use GPIO 13 instead)
+    pwm0 is GPIO pin 18 is physical pin 12 (dtoverlay can be deployed to use GPIO 12 (physical pin 32) instead)
+    pwm1 is GPIO pin 19 is physical pin 35 (dtoverlay can be deployed to use GPIO 13 (physical pin 33) instead)
 
     Example
     ----------


### PR DESCRIPTION
The physical pins defined in __init__.py were not matching to the GPIO pins. See: https://pinout.xyz/pinout/pwm